### PR TITLE
Add beach information dashboard web app

### DIFF
--- a/data/beachData.js
+++ b/data/beachData.js
@@ -1,0 +1,242 @@
+export const beaches = [
+  {
+    id: "haeundae",
+    name: "해운대 해수욕장",
+    region: "부산 해운대구",
+    status: "safe",
+    seaTemperature: 23.4,
+    waveHeight: 0.6,
+    windSpeed: 3.2,
+    ripCurrentRisk: "낮음",
+    jellyfishAlert: "관심",
+    safetyNotes: ["오전 10시부터 안전요원 상시 배치", "해양경찰 순찰 차량 30분 간격 운행"],
+    emergencyContacts: [
+      { type: "안전요원 본부", phone: "051-123-4567" },
+      { type: "해운대 해양경찰", phone: "112" }
+    ],
+    amenities: ["샤워장 5곳", "탈의실 3곳", "물놀이 용품 대여"],
+    events: [
+      {
+        name: "해운대 모래축제",
+        date: "6월 15일 - 6월 23일",
+        description: "샌드 보딩 체험, 야간 라이브 공연, 드론 라이트 쇼"
+      },
+      {
+        name: "썸머 무비 나이트",
+        date: "7월 매주 토요일",
+        description: "해변에서 즐기는 야외 영화 상영"
+      }
+    ],
+    buddyPosts: [
+      {
+        title: "새벽 서핑 같이 하실 분",
+        author: "연구원 김민수",
+        message: "06:00 입수 예정, 장비 대여 가능, 초보 환영"
+      },
+      {
+        title: "야간 피크닉 팀 모집",
+        author: "부산살아요",
+        message: "저녁 7시 모래사장, 간단한 보드게임 함께해요"
+      }
+    ],
+    sports: [
+      {
+        name: "스탠드업 패들보드",
+        difficulty: "초급",
+        contact: "해운대 워터클럽 051-345-9876"
+      },
+      {
+        name: "바나나보트",
+        difficulty: "가족형",
+        contact: "썸머웨이브 051-781-2234"
+      }
+    ],
+    personalizedTips: [
+      "일출 시간은 오전 5시 15분. 일찍 방문하면 한적한 분위기를 즐길 수 있어요.",
+      "해운대 전통시장과 연계한 먹거리 투어를 추천합니다."
+    ]
+  },
+  {
+    id: "gwangalli",
+    name: "광안리 해수욕장",
+    region: "부산 수영구",
+    status: "caution",
+    seaTemperature: 22.1,
+    waveHeight: 1.1,
+    windSpeed: 5.6,
+    ripCurrentRisk: "중간",
+    jellyfishAlert: "주의",
+    safetyNotes: [
+      "오후 2시 이후 파고 증가 예상",
+      "광안대교 인근 구역 출입 제한: 드론 촬영 행사"
+    ],
+    emergencyContacts: [
+      { type: "안내 센터", phone: "051-765-4321" },
+      { type: "수영구청 재난 상황실", phone: "051-610-4000" }
+    ],
+    amenities: ["무장애 데크 산책로", "반려견 동반 구역", "무료 공공 와이파이"],
+    events: [
+      {
+        name: "광안리 드론 라이트 쇼",
+        date: "상시 주말",
+        description: "국내 최대 규모의 정기 드론 불빛 공연"
+      },
+      {
+        name: "비치 클린업 데이",
+        date: "6월 29일",
+        description: "시민 참여형 해변 정화 캠페인"
+      }
+    ],
+    buddyPosts: [
+      {
+        title: "야경 촬영 크루 구합니다",
+        author: "사진가 최지훈",
+        message: "삼각대 공유 가능, 20시 광안대교 앞 집결"
+      },
+      {
+        title: "비치 발리볼 팀",
+        author: "광안리주민",
+        message: "매주 수/금 19시 연습, 초보 환영"
+      }
+    ],
+    sports: [
+      {
+        name: "요트 세일링 체험",
+        difficulty: "체험형",
+        contact: "광안리 요트투어 051-555-4412"
+      },
+      {
+        name: "카약 나이트 투어",
+        difficulty: "초중급",
+        contact: "문탠로드 카약 051-889-7771"
+      }
+    ],
+    personalizedTips: [
+      "야경 명소로 유명한 만큼, 삼각대와 망원 렌즈를 준비하면 좋아요.",
+      "광안리 해변로 카페 거리에서 야간 라이브 공연을 즐겨보세요."
+    ]
+  },
+  {
+    id: "songjeong",
+    name: "송정 해수욕장",
+    region: "부산 해운대구",
+    status: "safe",
+    seaTemperature: 21.7,
+    waveHeight: 0.8,
+    windSpeed: 4.0,
+    ripCurrentRisk: "낮음",
+    jellyfishAlert: "관심",
+    safetyNotes: [
+      "송정포구 인근 야간 취사 금지",
+      "서핑 강습 구역과 일반 물놀이 구역이 분리되어 있어요"
+    ],
+    emergencyContacts: [
+      { type: "송정 안전센터", phone: "051-123-1109" },
+      { type: "해운대구청 관광과", phone: "051-749-7641" }
+    ],
+    amenities: ["서핑 보드 렌탈샵 다수", "주차장 실시간 잔여석 안내", "캠핑 가능 구역"],
+    events: [
+      {
+        name: "송정 서핑 페스티벌",
+        date: "7월 6일 - 7월 7일",
+        description: "서핑 대회, 보드 시연, 해양 안전 워크숍"
+      },
+      {
+        name: "해변 요가 클래스",
+        date: "매주 일요일 08:00",
+        description: "현지 요가 강사와 함께 하는 모닝 요가"
+      }
+    ],
+    buddyPosts: [
+      {
+        title: "초보 서핑 클래스 같이 들을 분",
+        author: "서핑입문자",
+        message: "10시 강습, 장비 대여 포함, 3명 모집"
+      },
+      {
+        title: "드론 촬영 협업",
+        author: "콘텐츠제작자",
+        message: "서핑 영상 함께 제작하실 분 연락주세요"
+      }
+    ],
+    sports: [
+      {
+        name: "서핑 강습",
+        difficulty: "초중급",
+        contact: "송정서프스쿨 051-123-9090"
+      },
+      {
+        name: "프리다이빙 체험",
+        difficulty: "중급",
+        contact: "딥블루다이브 051-333-8880"
+      }
+    ],
+    personalizedTips: [
+      "물때 확인 후 방문하면 더 좋은 파도를 만날 수 있어요.",
+      "송정포구 횟집 거리에서 신선한 해산물을 맛보세요."
+    ]
+  }
+];
+
+export const featuredEvents = [
+  {
+    beachId: "haeundae",
+    title: "해운대 해양안전 캠프",
+    date: "6월 18일",
+    description: "해양경찰과 함께하는 안전 체험 프로그램",
+    tags: ["가족", "체험"]
+  },
+  {
+    beachId: "gwangalli",
+    title: "비치 요가 & 명상",
+    date: "6월 25일",
+    description: "해질녘 광안리에서 즐기는 웰니스 프로그램",
+    tags: ["웰니스", "무료"]
+  },
+  {
+    beachId: "songjeong",
+    title: "서핑 입문 원데이 클래스",
+    date: "6월 21일",
+    description: "전문 강사진과 함께 안전한 서핑 체험",
+    tags: ["서핑", "초보환영"]
+  }
+];
+
+export const buddyBoardPosts = [
+  {
+    title: "해양 쓰레기 줍깅 번개",
+    beach: "해운대",
+    time: "6월 16일 09:00",
+    message: "함께 쓰레기 줍고 브런치하실 분 모집해요",
+    tags: ["환경", "봉사"]
+  },
+  {
+    title: "비치 사운드 피크닉",
+    beach: "광안리",
+    time: "6월 22일 18:30",
+    message: "감성 플레이리스트 공유하면서 피크닉 해요",
+    tags: ["음악", "피크닉"]
+  },
+  {
+    title: "프리다이빙 버디",
+    beach: "송정",
+    time: "6월 29일 07:30",
+    message: "안전한 버디 다이빙 함께 하실 분 연락주세요",
+    tags: ["다이빙", "중급"]
+  }
+];
+
+export const marineSportsGuides = [
+  {
+    title: "부산 서핑 레벨 가이드",
+    description: "파도 크기와 수온에 따라 입문 · 중급 · 상급 포인트를 확인하세요."
+  },
+  {
+    title: "패들보드 안전 수칙",
+    description: "구명조끼 착용, 기상 체크, 리쉬 스트랩 확인은 필수!"
+  },
+  {
+    title: "야간 해변 활동 체크리스트",
+    description: "야간 조명 위치, CCTV 구간, 경찰 순찰 시간표를 확인하세요."
+  }
+];

--- a/index.html
+++ b/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>해수욕장 종합 정보 - 안전하고 즐거운 바다 여행</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Pretendard:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero__overlay"></div>
+      <div class="hero__content">
+        <h1>부산 해수욕장 종합 정보 허브</h1>
+        <p>
+          실시간 기상과 안전 정보부터, 주변 행사와 해양 스포츠까지.<br />
+          바다를 더 안전하고 재미있게 즐길 수 있는 모든 정보를 한 번에 확인하세요!
+        </p>
+        <div class="hero__actions">
+          <input
+            type="search"
+            id="searchInput"
+            placeholder="해수욕장 이름 또는 지역으로 검색"
+            aria-label="해수욕장 검색"
+          />
+          <div class="chip-group" role="group" aria-label="안전 필터">
+            <button class="chip active" data-filter="all">전체</button>
+            <button class="chip" data-filter="safe">안전</button>
+            <button class="chip" data-filter="caution">주의</button>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="layout">
+      <section class="panel" aria-label="해수욕장 목록">
+        <h2>오늘의 추천 해수욕장</h2>
+        <ul id="beachList" class="beach-list"></ul>
+        <p class="panel__hint">
+          안전 요원 배치, 해파리 출몰, 이안류 경보 등 꼭 알아야 할 안전 정보는
+          <strong>안전 인포 카드</strong>에서 확인할 수 있어요.
+        </p>
+      </section>
+
+      <section class="panel" aria-label="해수욕장 상세 정보">
+        <div id="detailView" class="detail">
+          <div class="empty-state">
+            <h3>해수욕장을 선택해 주세요</h3>
+            <p>
+              왼쪽 목록에서 해수욕장을 선택하면 실시간 기상, 안전, 행사 정보를
+              확인할 수 있습니다.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <section class="info-grid">
+      <article class="card" id="eventHighlights">
+        <h3>주요 행사 & 축제</h3>
+        <ul class="event-list"></ul>
+      </article>
+      <article class="card" id="buddyBoard">
+        <h3>같이 놀 사람 찾기</h3>
+        <ul class="buddy-list"></ul>
+      </article>
+      <article class="card" id="sportsInfo">
+        <h3>해양 스포츠 가이드</h3>
+        <ul class="sports-list"></ul>
+      </article>
+      <article class="card" id="personalTips">
+        <h3>맞춤 추천</h3>
+        <p class="personal-message">
+          즐겨찾기한 해수욕장이 아직 없어요. 마음에 드는 해수욕장을 즐겨찾기해 보세요!
+        </p>
+        <ul class="personal-list"></ul>
+      </article>
+    </section>
+
+    <footer class="footer">
+      <p>
+        데이터 출처: 부산시 해양 기상 관측소 · 해양수산부 안전해 서비스 · 지역 관광 정보
+      </p>
+      <p>© 2024 부산 해수욕장 파트너스</p>
+    </footer>
+
+    <script type="module" src="scripts/app.js"></script>
+  </body>
+</html>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,0 +1,371 @@
+import {
+  beaches,
+  featuredEvents,
+  buddyBoardPosts,
+  marineSportsGuides
+} from "../data/beachData.js";
+
+const beachList = document.getElementById("beachList");
+const detailView = document.getElementById("detailView");
+const searchInput = document.getElementById("searchInput");
+const chips = Array.from(document.querySelectorAll(".chip"));
+const eventList = document.querySelector("#eventHighlights .event-list");
+const buddyList = document.querySelector("#buddyBoard .buddy-list");
+const sportsList = document.querySelector("#sportsInfo .sports-list");
+const personalList = document.querySelector("#personalTips .personal-list");
+const personalMessage = document.querySelector("#personalTips .personal-message");
+
+const FAVORITE_KEY = "favorite-beaches";
+
+const storageAvailable =
+  typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+
+const readFavorites = () => {
+  if (!storageAvailable) return [];
+  try {
+    return JSON.parse(window.localStorage.getItem(FAVORITE_KEY) || "[]");
+  } catch (error) {
+    console.warn("즐겨찾기 정보를 불러오지 못했어요.", error);
+    return [];
+  }
+};
+
+const favoriteSet = new Set(readFavorites());
+
+const formatStatus = (status) => {
+  switch (status) {
+    case "safe":
+      return { label: "안전", className: "safe" };
+    case "caution":
+      return { label: "주의", className: "caution" };
+    default:
+      return { label: "경보", className: "alert" };
+  }
+};
+
+const formatMetric = (value, unit) => `${value.toFixed(1)}${unit}`;
+
+const renderBeaches = (filter = "all", term = "") => {
+  const keyword = term.trim().toLowerCase();
+
+  const filtered = beaches.filter((beach) => {
+    const matchesFilter = filter === "all" || beach.status === filter;
+    const matchesKeyword =
+      !keyword ||
+      beach.name.toLowerCase().includes(keyword) ||
+      beach.region.toLowerCase().includes(keyword);
+    return matchesFilter && matchesKeyword;
+  });
+
+  beachList.innerHTML = "";
+
+  if (!filtered.length) {
+    beachList.innerHTML = `<li class="empty-state">검색 결과가 없습니다.</li>`;
+    return;
+  }
+
+  filtered.forEach((beach) => {
+    const { label, className } = formatStatus(beach.status);
+    const card = document.createElement("li");
+    card.className = "beach-card";
+    card.tabIndex = 0;
+    card.innerHTML = `
+      <div class="beach-card__info">
+        <h3>${beach.name}</h3>
+        <p>${beach.region}</p>
+        <div class="detail__meta">
+          <span>해수온 ${formatMetric(beach.seaTemperature, "°C")}</span>
+          <span>파고 ${formatMetric(beach.waveHeight, "m")}</span>
+          <span>풍속 ${formatMetric(beach.windSpeed, "m/s")}</span>
+        </div>
+      </div>
+      <span class="status-badge ${className}">${label}</span>
+    `;
+
+    card.addEventListener("click", () => showBeachDetail(beach.id));
+    card.addEventListener("keypress", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        showBeachDetail(beach.id);
+      }
+    });
+
+    beachList.appendChild(card);
+  });
+};
+
+const renderMetrics = (beach) => `
+  <div class="metrics-grid">
+    <div class="metric-card">
+      <span>해수 온도</span>
+      <strong>${formatMetric(beach.seaTemperature, "°C")}</strong>
+    </div>
+    <div class="metric-card">
+      <span>파고</span>
+      <strong>${formatMetric(beach.waveHeight, "m")}</strong>
+    </div>
+    <div class="metric-card">
+      <span>풍속</span>
+      <strong>${formatMetric(beach.windSpeed, "m/s")}</strong>
+    </div>
+    <div class="metric-card">
+      <span>이안류 위험도</span>
+      <strong>${beach.ripCurrentRisk}</strong>
+    </div>
+  </div>
+`;
+
+const renderListItems = (items) =>
+  items.map((item) => `<li>${item}</li>`).join("");
+
+const renderContacts = (contacts) =>
+  contacts
+    .map((contact) => `<li><strong>${contact.type}</strong> · ${contact.phone}</li>`)
+    .join("");
+
+const renderEvents = (events) =>
+  events
+    .map(
+      (event) => `
+        <div class="event-item">
+          <h4>${event.name}</h4>
+          <p class="muted">${event.date}</p>
+          <p>${event.description}</p>
+        </div>
+      `
+    )
+    .join("");
+
+const renderBuddyPosts = (posts) =>
+  posts
+    .map(
+      (post) => `
+        <div class="buddy-item">
+          <h4>${post.title}</h4>
+          <p class="muted">${post.author}</p>
+          <p>${post.message}</p>
+        </div>
+      `
+    )
+    .join("");
+
+const renderSports = (sports) =>
+  sports
+    .map(
+      (sport) => `
+        <li class="list-pill">
+          <span>${sport.name}</span>
+          <span aria-hidden="true">·</span>
+          <span>${sport.difficulty}</span>
+          <span aria-hidden="true">·</span>
+          <span>${sport.contact}</span>
+        </li>
+      `
+    )
+    .join("");
+
+const updateFavorites = () => {
+  if (!storageAvailable) return;
+  try {
+    window.localStorage.setItem(
+      FAVORITE_KEY,
+      JSON.stringify(Array.from(favoriteSet))
+    );
+  } catch (error) {
+    console.warn("즐겨찾기 정보를 저장하지 못했어요.", error);
+  }
+  renderPersonalizedTips();
+};
+
+const showBeachDetail = (id) => {
+  const beach = beaches.find((item) => item.id === id);
+  if (!beach) return;
+
+  const { label, className } = formatStatus(beach.status);
+  const isFavorite = favoriteSet.has(beach.id);
+
+  detailView.innerHTML = `
+    <article class="detail__header">
+      <div class="detail__header-top">
+        <div>
+          <p class="status-badge ${className}">${label}</p>
+          <h3 class="detail__title">${beach.name}</h3>
+        </div>
+        <button class="favorite-btn ${isFavorite ? "is-favorite" : ""}" data-id="${beach.id}">
+          <span aria-hidden="true">${isFavorite ? "★" : "☆"}</span>
+          <span>${isFavorite ? "즐겨찾기됨" : "즐겨찾기"}</span>
+        </button>
+      </div>
+      <div class="detail__meta">
+        <span>${beach.region}</span>
+        <span>해파리 경보: ${beach.jellyfishAlert}</span>
+        <span>안전 메모: ${beach.safetyNotes[0]}</span>
+      </div>
+    </article>
+
+    <section class="info-section" aria-label="기상 정보">
+      <h4>기상 & 바다 상태</h4>
+      ${renderMetrics(beach)}
+    </section>
+
+    <section class="info-section" aria-label="안전 정보">
+      <h4>안전 인포 카드</h4>
+      <ul class="info-list">
+        ${renderListItems(beach.safetyNotes)}
+      </ul>
+      <h4>긴급 연락망</h4>
+      <ul class="info-list">
+        ${renderContacts(beach.emergencyContacts)}
+      </ul>
+    </section>
+
+    <section class="info-section" aria-label="편의 시설">
+      <h4>현장 편의 정보</h4>
+      <ul class="info-list">
+        ${renderListItems(beach.amenities)}
+      </ul>
+    </section>
+
+    <section class="info-section" aria-label="행사">
+      <h4>근처 행사 & 축제</h4>
+      ${renderEvents(beach.events)}
+    </section>
+
+    <section class="info-section" aria-label="커뮤니티">
+      <h4>커뮤니티 소식</h4>
+      ${renderBuddyPosts(beach.buddyPosts)}
+    </section>
+
+    <section class="info-section" aria-label="해양 스포츠">
+      <h4>추천 해양 스포츠</h4>
+      <ul class="pill-group">
+        ${renderSports(beach.sports)}
+      </ul>
+    </section>
+
+    <section class="info-section" aria-label="맞춤 추천">
+      <h4>맞춤 추천</h4>
+      <ul class="info-list">
+        ${renderListItems(beach.personalizedTips)}
+      </ul>
+    </section>
+  `;
+
+  const favoriteButton = detailView.querySelector(".favorite-btn");
+  favoriteButton.addEventListener("click", () => {
+    if (favoriteSet.has(beach.id)) {
+      favoriteSet.delete(beach.id);
+    } else {
+      favoriteSet.add(beach.id);
+    }
+    updateFavorites();
+    showBeachDetail(beach.id);
+  });
+};
+
+const renderGlobalEvents = () => {
+  eventList.innerHTML = featuredEvents
+    .map((event) => {
+      const beach = beaches.find((b) => b.id === event.beachId);
+      return `
+        <li class="event-item">
+          <h4>${event.title}</h4>
+          <p class="muted">${event.date} · ${beach?.name ?? "미확인"}</p>
+          <p>${event.description}</p>
+          <div class="event-tags">
+            ${event.tags.map((tag) => `<span class="tag">#${tag}</span>`).join("")}
+          </div>
+        </li>
+      `;
+    })
+    .join("");
+};
+
+const renderBuddyBoard = () => {
+  buddyList.innerHTML = buddyBoardPosts
+    .map(
+      (post) => `
+        <li class="buddy-item">
+          <h4>${post.title}</h4>
+          <p class="muted">${post.beach} · ${post.time}</p>
+          <p>${post.message}</p>
+          <div class="buddy-tags">
+            ${post.tags.map((tag) => `<span class="tag">#${tag}</span>`).join("")}
+          </div>
+        </li>
+      `
+    )
+    .join("");
+};
+
+const renderSportsGuides = () => {
+  sportsList.innerHTML = marineSportsGuides
+    .map(
+      (guide) => `
+        <li class="buddy-item">
+          <h4>${guide.title}</h4>
+          <p>${guide.description}</p>
+        </li>
+      `
+    )
+    .join("");
+};
+
+const renderPersonalizedTips = () => {
+  personalList.innerHTML = "";
+
+  if (!favoriteSet.size) {
+    personalMessage.textContent =
+      "즐겨찾기한 해수욕장이 아직 없어요. 마음에 드는 해수욕장을 즐겨찾기해 보세요!";
+    return;
+  }
+
+  const favoriteBeaches = beaches.filter((beach) => favoriteSet.has(beach.id));
+  const tips = favoriteBeaches.flatMap((beach) =>
+    beach.personalizedTips.map((tip) => ({
+      beach: beach.name,
+      message: tip
+    }))
+  );
+
+  personalMessage.textContent = `즐겨찾기한 ${favoriteBeaches
+    .map((beach) => beach.name)
+    .join(", ")} 맞춤 추천이에요.`;
+
+  personalList.innerHTML = tips
+    .map(
+      (tip) => `
+        <li class="buddy-item">
+          <h4>${tip.beach}</h4>
+          <p>${tip.message}</p>
+        </li>
+      `
+    )
+    .join("");
+};
+
+renderBeaches();
+renderGlobalEvents();
+renderBuddyBoard();
+renderSportsGuides();
+renderPersonalizedTips();
+
+searchInput.addEventListener("input", (event) => {
+  const activeChip = chips.find((chip) => chip.classList.contains("active"));
+  renderBeaches(activeChip?.dataset.filter ?? "all", event.target.value);
+});
+
+chips.forEach((chip) => {
+  chip.addEventListener("click", () => {
+    chips.forEach((item) => item.classList.remove("active"));
+    chip.classList.add("active");
+    renderBeaches(chip.dataset.filter, searchInput.value);
+  });
+});
+
+const initialFavorite = Array.from(favoriteSet)[0];
+if (initialFavorite) {
+  showBeachDetail(initialFavorite);
+} else {
+  showBeachDetail(beaches[0].id);
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,397 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f4f7fb;
+  --surface: rgba(255, 255, 255, 0.92);
+  --surface-strong: #ffffff;
+  --text: #1f2933;
+  --muted: #5d6b82;
+  --accent: #1a73e8;
+  --accent-soft: rgba(26, 115, 232, 0.1);
+  --warning: #f59e0b;
+  --danger: #ef4444;
+  --safe: #0ea5e9;
+  font-family: "Pretendard", "Apple SD Gothic Neo", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.hero {
+  position: relative;
+  padding: 4.5rem 2rem 6rem;
+  text-align: center;
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.85), rgba(14, 165, 233, 0.85)),
+    url("https://images.unsplash.com/photo-1511910849309-0e2a1549edc6?auto=format&fit=crop&w=1400&q=80")
+      center/cover no-repeat;
+  color: #fff;
+  overflow: hidden;
+}
+
+.hero__overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0));
+  z-index: 0;
+}
+
+.hero__content {
+  position: relative;
+  z-index: 1;
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.hero h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2rem, 3.5vw, 3.25rem);
+  font-weight: 700;
+}
+
+.hero p {
+  margin: 0 auto 2.5rem;
+  line-height: 1.6;
+  font-size: clamp(1rem, 1.6vw, 1.25rem);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  align-items: center;
+}
+
+.hero input[type="search"] {
+  width: min(420px, 100%);
+  padding: 0.9rem 1.1rem;
+  border-radius: 999px;
+  border: none;
+  font-size: 1rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.15);
+}
+
+.chip-group {
+  display: inline-flex;
+  gap: 0.5rem;
+  padding: 0.3rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.chip {
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.chip:hover,
+.chip:focus-visible {
+  background: rgba(255, 255, 255, 0.25);
+  transform: translateY(-1px);
+}
+
+.chip.active {
+  background: #fff;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+  padding: 2.5rem clamp(1.2rem, 3vw, 2.75rem);
+  margin-top: -3rem;
+}
+
+.panel {
+  background: var(--surface);
+  backdrop-filter: blur(16px);
+  border-radius: 24px;
+  padding: 1.8rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.1);
+}
+
+.panel h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+}
+
+.panel__hint {
+  margin-top: 1.5rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.beach-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.beach-card {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: var(--surface-strong);
+  border-radius: 18px;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  border: 1px solid transparent;
+}
+
+.beach-card:hover,
+.beach-card:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 28px rgba(15, 23, 42, 0.12);
+  border-color: rgba(26, 115, 232, 0.2);
+}
+
+.beach-card__info h3 {
+  margin: 0 0 0.3rem;
+  font-size: 1.2rem;
+}
+
+.beach-card__info p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.status-badge {
+  align-self: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.status-badge.safe {
+  background: rgba(14, 165, 233, 0.15);
+  color: var(--safe);
+}
+
+.status-badge.caution {
+  background: rgba(245, 158, 11, 0.18);
+  color: var(--warning);
+}
+
+.status-badge.alert {
+  background: rgba(239, 68, 68, 0.18);
+  color: var(--danger);
+}
+
+.detail {
+  min-height: 360px;
+}
+
+.empty-state {
+  text-align: center;
+  color: var(--muted);
+  padding: 4rem 1rem;
+}
+
+.detail__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.detail__header-top {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.detail__title {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.detail__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.favorite-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(26, 115, 232, 0.4);
+  background: rgba(26, 115, 232, 0.08);
+  color: var(--accent);
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.favorite-btn.is-favorite {
+  background: var(--accent);
+  color: #fff;
+}
+
+.info-section {
+  margin-bottom: 1.8rem;
+}
+
+.info-section h4 {
+  margin: 0 0 0.8rem;
+  font-size: 1.1rem;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.metric-card {
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.metric-card strong {
+  display: block;
+  font-size: 1.4rem;
+  margin-top: 0.3rem;
+}
+
+.list-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.05);
+  margin: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.info-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.info-list li {
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.05);
+  line-height: 1.5;
+}
+
+.pill-group {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pill-group .list-pill {
+  margin: 0;
+}
+
+.event-item,
+.buddy-item {
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.04);
+  margin-bottom: 0.75rem;
+}
+
+.event-item h4,
+.buddy-item h4 {
+  margin: 0 0 0.35rem;
+  font-size: 1.05rem;
+}
+
+.event-tags,
+.buddy-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 0.5rem;
+}
+
+.tag {
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(26, 115, 232, 0.12);
+  color: var(--accent);
+  font-size: 0.8rem;
+}
+
+.info-grid {
+  display: grid;
+  gap: 1.5rem;
+  padding: 0  clamp(1.2rem, 3vw, 2.75rem) 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  background: var(--surface);
+  backdrop-filter: blur(16px);
+  border-radius: 24px;
+  padding: 1.6rem;
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.08);
+}
+
+.footer {
+  text-align: center;
+  padding: 2.5rem 1rem 3rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding: 3.5rem 1.2rem 5rem;
+  }
+
+  .layout {
+    margin-top: -2.5rem;
+  }
+
+  .panel {
+    padding: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add static landing page that aggregates Busan beach weather, safety, and event data
- provide interactive filtering, detailed cards, and personalized favorites powered by local storage
- include companion sections for events, buddy matching, and marine sports guidance

## Testing
- no automated tests were run (project is static web content)


------
https://chatgpt.com/codex/tasks/task_e_68db57a1b9208330a201423feff720b8